### PR TITLE
Modify the return type of output method (#34)

### DIFF
--- a/pysimenv/common/model.py
+++ b/pysimenv/common/model.py
@@ -289,10 +289,10 @@ class Dyn6DOF(DynSystem):
         return {'p': p_dot, 'v_b': v_b_dot, 'q': q_dot, 'omega': omega_dot}
 
     # override
-    def _forward(self, **kwargs):
-        output = super(Dyn6DOF, self)._forward(**kwargs)
-        self._logger.append(R=self.R, v_i=self.v_i)
-        return output
+    def _output(self) -> Union[None, np.ndarray, dict]:
+        out = self.state()
+        out.update({'R': self.R, 'v_i': self.v_i})
+        return out
 
 
 class Dyn6DOFEuler(DynSystem):
@@ -338,10 +338,10 @@ class Dyn6DOFEuler(DynSystem):
         return {'p': p_dot, 'v_b': v_b_dot, 'eta': eta_dot, 'omega': omega_dot}
 
     # override
-    def _forward(self, **kwargs):
-        output = super(Dyn6DOFEuler, self)._forward(**kwargs)
-        self._logger.append(R=self.R, v_i=self.v_i)
-        return output
+    def _output(self) -> Union[None, np.ndarray, dict]:
+        out = self.state()
+        out.update({'R': self.R, 'v_i': self.v_i})
+        return out
 
 
 class Dyn6DOFRotMat(DynSystem):
@@ -369,8 +369,7 @@ class Dyn6DOFRotMat(DynSystem):
         return {'p': p_dot, 'v_b': v_b_dot, 'R': R_dot, 'omega': omega_dot}
 
     # override
-    def _forward(self, **kwargs):
-        output = super(Dyn6DOFRotMat, self)._forward(**kwargs)
-        self._logger.append(v_i=self.v_i)
-        return output
-
+    def _output(self) -> Union[None, np.ndarray, dict]:
+        out = self.state()
+        out.update({'v_i': self.v_i})
+        return out

--- a/pysimenv/core/base.py
+++ b/pysimenv/core/base.py
@@ -16,6 +16,8 @@ class StateVariable(object):
         self.correction_fun = None
 
     def apply_state(self, state: ArrayType):
+        if isinstance(state, float):
+            state = np.array([state])
         self.state = np.array(state)
 
     @property

--- a/pysimenv/core/base.py
+++ b/pysimenv/core/base.py
@@ -169,7 +169,7 @@ class SimObject(object):
         return NotImplementedError
 
     @property
-    def output(self) -> Union[None, tuple, np.ndarray]:
+    def output(self) -> Union[None, np.ndarray, dict]:
         return self._last_output
 
     def history(self, *args):
@@ -192,7 +192,7 @@ class StaticObject(SimObject):
         self.eval_fun = eval_fun
 
     # override
-    def forward(self, *args, **kwargs):
+    def forward(self, *args, **kwargs) -> Union[None, np.ndarray, dict]:
         self._timer.forward()
         if self._timer.is_event:
             self._last_output = self._forward(*args, **kwargs)
@@ -200,7 +200,7 @@ class StaticObject(SimObject):
         return self._last_output
 
     # may be implemented
-    def _forward(self, *args, **kwargs):
+    def _forward(self, *args, **kwargs) -> Union[None, np.ndarray, dict]:
         if self.eval_fun is None:
             raise NotImplementedError
         else:

--- a/pysimenv/core/simulator.py
+++ b/pysimenv/core/simulator.py
@@ -11,7 +11,7 @@ from pysimenv.core.system import DynObject
 
 
 class Simulator(object):
-    def __init__(self, model: DynObject, verbose: bool = True):
+    def __init__(self, model: DynObject, verbose: bool = True, reset_model: bool = True):
         self.sim_clock = SimClock()
         self.log_timer = Timer(np.inf)
         self.log_timer.attach_sim_clock(self.sim_clock)
@@ -19,6 +19,8 @@ class Simulator(object):
         self.model = model
         self.model.attach_sim_clock(self.sim_clock)
         self.model.attach_log_timer(self.log_timer)
+        if reset_model:
+            self.model.reset()
 
         self.verbose = verbose
 

--- a/pysimenv/core/system.py
+++ b/pysimenv/core/system.py
@@ -154,26 +154,6 @@ class DynObject(SimObject):
             derivs[name] = var.deriv
         return derivs
 
-    # @property
-    # def state(self) -> Dict[str, np.ndarray]:
-    #     return self._get_states()
-    #
-    # def _get_states(self) -> Dict[str, np.ndarray]:
-    #     states = dict()
-    #     for name, var in self.state_vars.items():
-    #         states[name] = var.state
-    #     return states
-    #
-    # @property
-    # def deriv(self) -> Dict[str, np.ndarray]:
-    #     return self._get_deriv()
-    #
-    # def _get_deriv(self) -> Dict[str, np.ndarray]:
-    #     derivs = dict()
-    #     for name, var in self.state_vars.items():
-    #         derivs[name] = var.deriv
-    #     return derivs
-
 
 class DynSystem(DynObject):
     def __init__(self, initial_states: Dict[str, ArrayType], deriv_fun=None, output_fun=None,
@@ -209,7 +189,7 @@ class DynSystem(DynObject):
         return self.deriv_fun(**kwargs)
 
     # override
-    def forward(self, **kwargs):
+    def forward(self, **kwargs) -> Union[None, np.ndarray, dict]:
         self._timer.forward()
         output = self._forward(**kwargs)
 
@@ -219,7 +199,7 @@ class DynSystem(DynObject):
         return self._last_output
 
     # implement
-    def _forward(self, **kwargs):
+    def _forward(self, **kwargs) -> Union[None, np.ndarray, dict]:
         states = self._get_states()
         derivs = self._deriv(**states, **kwargs)
 
@@ -231,11 +211,11 @@ class DynSystem(DynObject):
 
     # override
     @property
-    def output(self) -> Optional[np.ndarray]:
+    def output(self) -> Union[None, np.ndarray, dict]:
         return self._output()
 
     # may be overridden
-    def _output(self) -> Optional[np.ndarray]:
+    def _output(self) -> Union[None, np.ndarray, dict]:
         if self.output_fun is None:
             return None
         else:
@@ -272,7 +252,7 @@ class TimeVaryingDynSystem(DynObject):
         return self.deriv_fun(t, **kwargs)
 
     # implement
-    def _forward(self, **kwargs):
+    def _forward(self, **kwargs) -> Union[None, np.ndarray, dict]:
         states = self._get_states()
         derivs = self._deriv(t=self.time, **states, **kwargs)
 
@@ -284,11 +264,11 @@ class TimeVaryingDynSystem(DynObject):
 
     # override
     @property
-    def output(self) -> Optional[np.ndarray]:
+    def output(self) -> Union[None, np.ndarray, dict]:
         return self._output()
 
     # may be overridden
-    def _output(self) -> Optional[np.ndarray]:
+    def _output(self) -> Union[None, np.ndarray, dict]:
         if self.output_fun is None:
             return None
         else:
@@ -350,12 +330,6 @@ class MultipleSystem(DynObject, ABC):
         super(MultipleSystem, self).check_sim_clock()
         for sim_obj in self.sim_obj_list:
             sim_obj.check_sim_clock()
-
-    # override
-    def check_log_timer(self):
-        super(MultipleSystem, self).check_log_timer()
-        for sim_obj in self.sim_obj_list:
-            sim_obj.check_log_timer()
 
     # implement
     def check_stop_condition(self) -> Tuple[bool, list]:

--- a/pysimenv/core/util.py
+++ b/pysimenv/core/util.py
@@ -38,7 +38,8 @@ class Timer(object):
         self._last_event_time = -np.inf
 
     def reset(self):
-        self.turn_off()
+        self.turn_on()
+        self._last_event_time = -np.inf
 
     def attach_sim_clock(self, sim_clock: SimClock):
         # initialization phase

--- a/pysimenv/example/example_feedback_control.py
+++ b/pysimenv/example/example_feedback_control.py
@@ -2,7 +2,7 @@ import numpy as np
 from pysimenv.core.base import StaticObject
 from pysimenv.core.simulator import Simulator
 from pysimenv.core.system import DynSystem
-from pysimenv.common.model import FeedbackControl
+from pysimenv.common.model import OFBControl
 
 
 def main():
@@ -54,7 +54,7 @@ def main():
         output_fun=lambda x: C.dot(x)
     )
     control = StaticObject(interval=-1, eval_fun=lambda y: -K.dot(y))
-    model = FeedbackControl(linear_system, control)  # closed-loop system
+    model = OFBControl(linear_system, control)  # closed-loop system
 
     simulator = Simulator(model)
     simulator.propagate(dt=0.01, time=10.)

--- a/pysimenv/test/compare_dyn6dof.py
+++ b/pysimenv/test/compare_dyn6dof.py
@@ -1,6 +1,6 @@
 import numpy as np
 import matplotlib.pyplot as plt
-from pysimenv.common.model import Dyn6DOF, Dyn6DOFEuler, Dyn6DOFRotMat, SignalGenerator, Sequential
+from pysimenv.common.model import Dyn6DOF, Dyn6DOFEuler, Dyn6DOFRotMat, SignalGenerator, Sequential, Scope
 from pysimenv.core.simulator import Simulator
 
 
@@ -33,17 +33,18 @@ def main():
             m_b = np.zeros(3)
         return {'f_b': f_b, 'm_b': m_b}
     source = SignalGenerator(shaping_fun=force_moment)
+    scope = Scope()
     models = {
-        'quaternion': Sequential(obj_list=[source, dyn6dof]),
-        'euler': Sequential(obj_list=[source, dyn6dof_euler]),
-        'rot_mat': Sequential(obj_list=[source, dyn6dof_rot_mat])
+        'quaternion': Sequential(obj_list=[source, dyn6dof, scope]),
+        'euler': Sequential(obj_list=[source, dyn6dof_euler, scope]),
+        'rot_mat': Sequential(obj_list=[source, dyn6dof_rot_mat, scope])
     }
     line_styles = {'quaternion': '-', 'euler': '-.', 'rot_mat': ':'}
     rotations = dict()
     for key, model in models.items():
         simulator = Simulator(model)
         simulator.propagate(dt=0.01, time=20., save_history=True)
-        rotations[key] = {'t': model.obj_list[1].history('t'), 'R': model.obj_list[1].history('R')}
+        rotations[key] = {'t': model.obj_list[2].history('t'), 'R': model.obj_list[2].history('R')}
 
     fig, ax = plt.subplots(3, 3)
     for i in range(3):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysimenv",
-    version="0.0.9",
+    version="0.0.10",
     author="Sangmin Lee",
     author_email="everlastingminii@gmail.com",
     description="A framework for performing numerical simulation of dynamic systems",


### PR DESCRIPTION
* The return type of the output of SimObject instances can be either `numpy.ndarray` type or `dict` type.
* Reset method of the simulated model is called when a `Simulator` instance is initialized.